### PR TITLE
Fix collector url of grpc

### DIFF
--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/controller/AgentController.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/controller/AgentController.kt
@@ -41,10 +41,8 @@ class AgentController(
     @GetMapping(V5_INIT_CONFIG, produces = [MediaType.APPLICATION_JSON_VALUE])
     fun grpcInitConfig(@RequestParam licenseKey: String, request: HttpServletRequest): InitConfigResponse {
         logger.info { "init config requested from grpc client ${request.remoteAddr} with licenseKey: $licenseKey" }
-        val splitUrl = request.requestURL.split("/")
-        val collectorUrl = "${splitUrl[0]}//${splitUrl[2]}"
         return InitConfigResponse.newBuilder()
-            .setCollectorUrl(collectorUrl)
+            .setCollectorUrl(request.requestURL.split("/")[2])
             .build()
     }
 


### PR DESCRIPTION
~앞에 프로토콜은 없앴습니다.~ collector url을 `host:port`로 변경합니다. OkHttpChannel을 생성할 때 `host:port`만 넘겨줘야합니다.
예) `http://localhost:8080` -> `localhost:8080`
만약 프로토콜까지 넘겨주는 경우 발생하는 에러는 아래와 같습니다.
 ```
java.lang.IllegalArgumentException: cannot find a NameResolver for http://localhost:8080
        at sc.io.grpc.internal.ManagedChannelImpl.getNameResolver(ManagedChannelImpl.java:776) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at sc.io.grpc.internal.ManagedChannelImpl.getNameResolver(ManagedChannelImpl.java:785) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at sc.io.grpc.internal.ManagedChannelImpl.<init>(ManagedChannelImpl.java:665) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at sc.io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:630) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at sc.io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:297) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.publishing.GrpcClient.createChannel(GrpcClient.java:86) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.publishing.GrpcClient.createNewChannelIfShutdown(GrpcClient.java:69) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.publishing.GrpcClient.pollConfig(GrpcClient.java:33) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.publishing.Publisher.pollDynamicConfig(Publisher.java:99) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.scheduling.Scheduler.pollDynamicConfigIfNeeded(Scheduler.java:126) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at com.navercorp.scavenger.javaagent.scheduling.Scheduler.run(Scheduler.java:114) ~[scavenger-agent-java-1.0.3.jar:1.0.3]
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[na:na]
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[na:na]
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]

```