### PR TITLE
Revert clean up code

### DIFF
--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/controller/DiagnosisController.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/controller/DiagnosisController.kt
@@ -18,6 +18,7 @@ import javax.servlet.http.HttpServletResponse
 import kotlin.io.path.getLastModifiedTime
 import kotlin.io.path.isDirectory
 import kotlin.io.path.name
+import kotlin.streams.toList
 
 @RequestMapping("/diag")
 @Controller


### PR DESCRIPTION
Revert #26 

`toList()`  is in use in the code on the next line.

```kotlin
        val files = Files.list(Paths.get("$diagDirectory/$path")).sorted().toList()
```