### PR TITLE
Modify JVM options order at run-agent.sh

### DIFF
--- a/run-agent.sh
+++ b/run-agent.sh
@@ -4,6 +4,6 @@
 ./gradlew build -p scavenger-demo -x test
 
 java -Dscavenger.configuration=./scavenger-demo/scavenger.conf  \
-     -javaagent:$(find scavenger-agent-java/build/libs/scavenger-agent-java-*.jar | tail -1) \
      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+     -javaagent:$(find scavenger-agent-java/build/libs/scavenger-agent-java-*.jar | tail -1) \
      -jar $(find scavenger-demo/build/libs/scavenger-demo-*.jar | tail -1)

--- a/run-old-agent.sh
+++ b/run-old-agent.sh
@@ -4,6 +4,6 @@
 ./gradlew build -p scavenger-demo -x test
 
 java -Dscavenger.configuration=./scavenger-demo/scavenger.conf  \
-     -javaagent:$(find scavenger-old-agent-java/build/libs/scavenger-old-agent-java-*.jar | tail -1) \
      -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 \
+     -javaagent:$(find scavenger-old-agent-java/build/libs/scavenger-old-agent-java-*.jar | tail -1) \
      -jar $(find scavenger-demo/build/libs/scavenger-demo-*.jar | tail -1)


### PR DESCRIPTION
Depending on where the `-agentlib` option is located, the behavior seems different.
I think it's better for debugging if the `-agentlib` option should come before the `-javaagent` option.

- original 
> It starts listening to dt_socket just before demo.jar starts.

![image](https://user-images.githubusercontent.com/122586083/222617789-a98aa1d0-9686-4f1f-adae-7ce8d8400293.png)

- changed
> It starts listening to dt_socket before scavenger-agent starts

![image](https://user-images.githubusercontent.com/122586083/222617747-88179bd6-b339-4195-8d29-4ecba2c55c3d.png)
