### PR TITLE
Fail integration test when no jdk1.7 exists

### DIFF
--- a/scavenger-old-agent-java/build.gradle.kts
+++ b/scavenger-old-agent-java/build.gradle.kts
@@ -104,9 +104,14 @@ tasks.withType<Test> {
 }
 
 val javaPath = { version: Int ->
-    "$version:" + javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(version))
-    }.get().executablePath
+        try {
+            "$version:" + javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(version))
+            }.get().executablePath
+        } catch (e : Exception) {
+            logger.warn("The scavenger old agent should be built on JDK1.7. But it does not exist in this build", e)
+            ""
+        }
 }
 
 testSets {

--- a/scavenger-old-agent-java/src/integrationTest/java/integrationTest/javaagent/JavaAgentIntegrationTest.java
+++ b/scavenger-old-agent-java/src/integrationTest/java/integrationTest/javaagent/JavaAgentIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedReader;
@@ -61,7 +62,7 @@ public class JavaAgentIntegrationTest {
         assertNotNull("This test must be started from Gradle", codekvastAgentPath);
         assertNotNull("This test must be started from Gradle", classpath);
         assertNotNull("This test must be started from Gradle", javaPaths);
-
+        assertFalse("This test must be tested with JDK1.7", javaPaths.isEmpty());
         wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
         wireMockServer.start();
         WireMock.configureFor(wireMockServer.port());
@@ -69,7 +70,9 @@ public class JavaAgentIntegrationTest {
 
     @AfterClass
     public static void afterAll() {
-        wireMockServer.shutdown();
+        if (wireMockServer != null) {
+            wireMockServer.shutdown();
+        }
     }
 
     private static List<String> getJavaVersions() {


### PR DESCRIPTION
Prevent scavenger project intellij import failure when the no JDK1.7 exists
- old-agent should not block whole project import. because it will be rarely compiled.