### PR TITLE
Modify to use build instead of assemble at release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "tag=$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
         id: extract_tag_version
       - name: Build project
-        run: ./gradlew assemble
+        run: ./gradlew clean build
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
If use `assemble` when building project, it cannot include `Premain-Class` to manifest attribute to agent.
So we have the following error.
```
Failed to find Premain-Class manifest attribute in scavenger-agent-java-1.0.5-SNAPSHOT.jar
Error occurred during initialization of VM
agent library failed to init: instrument
```
Change the release workflow to use `build`.