### PR TITLE
sweep jvms without agent

### DIFF
--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
@@ -52,7 +52,7 @@ class JvmDao(
         )
     }
 
-    fun findUuidsByWithoutAgent(customerId: Long): List<String> {
+    fun findAllUuidsByWithoutAgent(customerId: Long): List<String> {
         return select(
             sql.selectUuidsByWithoutAgent(),
             mapParameterSource()

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
@@ -51,4 +51,11 @@ class JvmDao(
                 .addValue("uuids", uuids)
         )
     }
+
+    fun deleteAllByWithoutAgent(): Int {
+        return update(
+            sql.deleteAllByWithoutAgent(),
+            mapParameterSource()
+        )
+    }
 }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
@@ -52,13 +52,6 @@ class JvmDao(
         )
     }
 
-    fun deleteAllByWithoutAgent(): Int {
-        return update(
-            sql.deleteAllByWithoutAgent(),
-            mapParameterSource()
-        )
-    }
-
     fun findUuidsByWithoutAgent(customerId: Long): List<String> {
         return select(
             sql.selectUuidsByWithoutAgent(),

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
@@ -54,7 +54,7 @@ class JvmDao(
 
     fun findAllUuidsByWithoutAgent(customerId: Long): List<String> {
         return select(
-            sql.selectUuidsByWithoutAgent(),
+            sql.selectAllUuidsByWithoutAgent(),
             mapParameterSource()
                 .addValue("customerId", customerId),
             String::class.java

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/JvmDao.kt
@@ -58,4 +58,13 @@ class JvmDao(
             mapParameterSource()
         )
     }
+
+    fun findUuidsByWithoutAgent(customerId: Long): List<String> {
+        return select(
+            sql.selectUuidsByWithoutAgent(),
+            mapParameterSource()
+                .addValue("customerId", customerId),
+            String::class.java
+        )
+    }
 }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
@@ -56,19 +56,6 @@ class JvmSql : SqlGeneratorSupport() {
             AND uuid IN ( :uuids )
         """.trimIndent()
 
-    fun deleteAllByWithoutAgent(): String =
-        """
-            DELETE FROM
-                jvms
-            WHERE
-                uuid NOT IN (
-                    SELECT
-                        jvmUuid
-                    FROM
-                        agent_state
-                )
-        """.trimIndent()
-
     fun selectUuidsByWithoutAgent(): String =
         """
            SELECT uuid FROM

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
@@ -55,4 +55,17 @@ class JvmSql : SqlGeneratorSupport() {
             customerId = :customerId
             AND uuid IN ( :uuids )
         """.trimIndent()
+
+    fun deleteAllByWithoutAgent(): String =
+        """
+            DELETE FROM
+                jvms
+            WHERE
+                uuid NOT IN (
+                    SELECT
+                        jvmUuid
+                    FROM
+                        agent_state
+                )
+        """.trimIndent()
 }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
@@ -56,7 +56,7 @@ class JvmSql : SqlGeneratorSupport() {
             AND uuid IN ( :uuids )
         """.trimIndent()
 
-    fun selectUuidsByWithoutAgent(): String =
+    fun selectAllUuidsByWithoutAgent(): String =
         """
            SELECT uuid FROM
                 jvms

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/repository/sql/JvmSql.kt
@@ -68,4 +68,18 @@ class JvmSql : SqlGeneratorSupport() {
                         agent_state
                 )
         """.trimIndent()
+
+    fun selectUuidsByWithoutAgent(): String =
+        """
+           SELECT uuid FROM
+                jvms
+           WHERE
+                customerId = :customerId
+                AND uuid NOT IN (
+                    SELECT
+                        jvmUuid
+                    FROM
+                        agent_state
+                )
+        """.trimIndent()
 }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
@@ -101,7 +101,7 @@ class GarbageCollectService(
                     customerId,
                     baseDateTime.minusMillis(intervalService.batchSweepMarginMilliSecond)
                 )
-                val jvmUuids = jvmDao.findUuidsByWithoutAgent(customerId)
+                val jvmUuids = jvmDao.findAllUuidsByWithoutAgent(customerId)
 
                 jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + jvmUuids)
                     .also { logger.info { "[$customerId] $it jvm is swiped. " } }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
@@ -101,9 +101,9 @@ class GarbageCollectService(
                     customerId,
                     baseDateTime.minusMillis(intervalService.batchSweepMarginMilliSecond)
                 )
-                val uuidsWithougAgent = jvmDao.findAllUuidsByWithoutAgent(customerId)
+                val uuidsWithoutAgent = jvmDao.findAllUuidsByWithoutAgent(customerId)
 
-                jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + uuidsWithougAgent)
+                jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + uuidsWithoutAgent)
                     .also { logger.info { "[$customerId] $it jvm is swiped. " } }
                 agentStateDao.deleteAllByCustomerIdAndIds(customerId, agentStates.map { it.id })
                     .also { logger.info { "[$customerId] $it agent state is swiped. " } }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
@@ -70,6 +70,8 @@ class GarbageCollectService(
                 }
                 logger.info { "[$it] hourly batch took $millis ms" }
             }
+
+        sweepJvmsWithoutAgent()
     }
 
     /**
@@ -89,6 +91,14 @@ class GarbageCollectService(
             .forEach {
                 sweepMethods(it, now)
             }
+    }
+
+    fun sweepJvmsWithoutAgent() {
+        try {
+            jvmDao.deleteAllByWithoutAgent()
+        } catch (e: Exception) {
+            logger.warn(e) { "error occurred while sweepJvmsWithoutAgent, but ignored. " }
+        }
     }
 
     /**

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
@@ -101,9 +101,9 @@ class GarbageCollectService(
                     customerId,
                     baseDateTime.minusMillis(intervalService.batchSweepMarginMilliSecond)
                 )
-                val jvmUuids = jvmDao.findAllUuidsByWithoutAgent(customerId)
+                val uuidsWithougAgent = jvmDao.findAllUuidsByWithoutAgent(customerId)
 
-                jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + jvmUuids)
+                jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + uuidsWithougAgent)
                     .also { logger.info { "[$customerId] $it jvm is swiped. " } }
                 agentStateDao.deleteAllByCustomerIdAndIds(customerId, agentStates.map { it.id })
                     .also { logger.info { "[$customerId] $it agent state is swiped. " } }

--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/service/GarbageCollectService.kt
@@ -101,7 +101,7 @@ class GarbageCollectService(
                     customerId,
                     baseDateTime.minusMillis(intervalService.batchSweepMarginMilliSecond)
                 )
-                var jvmUuids = jvmDao.findUuidsByWithoutAgent(customerId)
+                val jvmUuids = jvmDao.findUuidsByWithoutAgent(customerId)
 
                 jvmDao.deleteAllByCustomerIdAndUuids(customerId, agentStates.map { it.jvmUuid } + jvmUuids)
                     .also { logger.info { "[$customerId] $it jvm is swiped. " } }

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
@@ -34,6 +35,20 @@ class JvmDaoTest {
             hostname = "AL01978856.local",
         )
 
+        val paramWithoutAgent = JvmUpsertParam(
+            customerId = 3,
+            applicationId = applicationId,
+            applicationVersion = "unspecified",
+            environmentId = environmentId,
+            uuid = "9ec4624c-5b81-44fa-82c8-74233095b120",
+            codeBaseFingerprint = "CodeBaseFingerprint(numClassFiles=0, numJarFiles=1, " +
+                "sha256=b90e15678202f78cee45fa05cef8cba7c070114e37e81ff9131858c1d9c488c7)",
+            publishedAt = instant,
+            createdAt = instant,
+            hostname = "AL01978856.local",
+        )
+
+        sut.upsert(param)
         sut.upsert(param)
     }
 
@@ -67,5 +82,11 @@ class JvmDaoTest {
     fun deleteGarbagePublishedBefore() {
         sut.deleteGarbagePublishedBefore(2, Instant.now())
         assertThat(sut.findByCustomerIdAndUuid(2, "d0dfa3c2-809c-428f-b501-7419196d91c5")).isNull()
+    }
+
+    @Test
+    fun deleteAllByWithoutAgent() {
+        sut.deleteAllByWithoutAgent()
+        assertThat(sut.findByCustomerIdAndUuid(3, "9ec4624c-5b81-44fa-82c8-74233095b120")).isNull()
     }
 }

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -48,7 +48,7 @@ class JvmDaoTest {
         )
 
         sut.upsert(param)
-        sut.upsert(param)
+        sut.upsert(paramWithoutAgent)
     }
 
     @Test

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -84,6 +84,13 @@ class JvmDaoTest {
     }
 
     @Test
+    fun selectUuidsByWithoutAgent() {
+        val jvmUuids = sut.findUuidsByWithoutAgent(3)
+        assertThat(jvmUuids).isNotEmpty
+        assertThat(jvmUuids).contains("9ec4624c-5b81-44fa-82c8-74233095b120")
+    }
+
+    @Test
     fun deleteAllByWithoutAgent() {
         sut.deleteAllByWithoutAgent()
         assertThat(sut.findByCustomerIdAndUuid(3, "9ec4624c-5b81-44fa-82c8-74233095b120")).isNull()

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -89,10 +89,4 @@ class JvmDaoTest {
         assertThat(jvmUuids).isNotEmpty
         assertThat(jvmUuids).contains("9ec4624c-5b81-44fa-82c8-74233095b120")
     }
-
-    @Test
-    fun deleteAllByWithoutAgent() {
-        sut.deleteAllByWithoutAgent()
-        assertThat(sut.findByCustomerIdAndUuid(3, "9ec4624c-5b81-44fa-82c8-74233095b120")).isNull()
-    }
 }

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/repository/JvmDaoTest.kt
@@ -85,7 +85,7 @@ class JvmDaoTest {
 
     @Test
     fun selectUuidsByWithoutAgent() {
-        val jvmUuids = sut.findUuidsByWithoutAgent(3)
+        val jvmUuids = sut.findAllUuidsByWithoutAgent(3)
         assertThat(jvmUuids).isNotEmpty
         assertThat(jvmUuids).contains("9ec4624c-5b81-44fa-82c8-74233095b120")
     }

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/service/GarbageCollectServiceTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/service/GarbageCollectServiceTest.kt
@@ -246,7 +246,7 @@ class GarbageCollectServiceTest {
 
     @Nested
     @DisplayName("if without agent state exists")
-    inner class WithoutAgentJvms() {
+    inner class WithoutAgentJvms {
         val now = Instant.now()
         val ago = now.minus(600 + IntervalService.Companion.GC_DEAD_MARGIN_MINUTES * 60, ChronoUnit.SECONDS)
 
@@ -297,8 +297,8 @@ class GarbageCollectServiceTest {
         }
 
         @Test
-        fun sweepAgentStatesAndJvms() {
-            sut.sweepJvmsWithoutAgent()
+        fun sweepAgentStatesAndJvms_removeWithoutAgentJvms() {
+            sut.sweepAgentStatesAndJvms(customerId, now)
             assertThat(jvmDao.findAllByCustomerId(customerId).size).isEqualTo(1)
         }
     }

--- a/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/service/GarbageCollectServiceTest.kt
+++ b/scavenger-collector/src/test/kotlin/com/navercorp/scavenger/service/GarbageCollectServiceTest.kt
@@ -243,4 +243,63 @@ class GarbageCollectServiceTest {
                 .hasSize(3)
         }
     }
+
+    @Nested
+    @DisplayName("if without agent state exists")
+    inner class WithoutAgentJvms() {
+        val now = Instant.now()
+        val ago = now.minus(600 + IntervalService.Companion.GC_DEAD_MARGIN_MINUTES * 60, ChronoUnit.SECONDS)
+
+        @BeforeEach
+        fun beforeEach() {
+            // Clean up first
+            jvmDao.findAllByCustomerId(customerId).forEach {
+                jvmDao.deleteById(it.id)
+            }
+
+            jvmDao.insert(
+                JvmEntity(
+                    customerId = customerId,
+                    applicationId = 1,
+                    environmentId = 1,
+                    uuid = "uuid",
+                    codeBaseFingerprint = null,
+                    createdAt = ago,
+                    publishedAt = ago,
+                    hostname = "hostname",
+                )
+            )
+
+            jvmDao.insert(
+                JvmEntity(
+                    customerId = customerId,
+                    applicationId = 1,
+                    environmentId = 1,
+                    uuid = "withoutUUID",
+                    codeBaseFingerprint = null,
+                    createdAt = ago,
+                    publishedAt = ago,
+                    hostname = "hostname",
+                )
+            )
+
+            agentStateDao.insert(
+                AgentStateEntity(
+                    customerId = customerId,
+                    jvmUuid = "uuid",
+                    createdAt = ago,
+                    lastPolledAt = ago,
+                    nextPollExpectedAt = ago.plusSeconds(60),
+                    timestamp = ago,
+                    enabled = true,
+                )
+            )
+        }
+
+        @Test
+        fun sweepAgentStatesAndJvms() {
+            sut.sweepJvmsWithoutAgent()
+            assertThat(jvmDao.findAllByCustomerId(customerId).size).isEqualTo(1)
+        }
+    }
 }


### PR DESCRIPTION
Hello,

I'm currently using a scavenger and I've encountered a problem where deleted methods are not getting garbage collected. Upon inspecting the collector code, it seems that the method garbage collection marks methods collected before the earliest CreatedAt value of CodebaseFingerprints owned by the Customer, then proceeds with the sweep. Also, CodebaseFingerprints are updated along with the JVM.

For JVM to be updated, an AgentState is required. However, there was a JVM that didn't have an AgentState. I'm unsure of the cause of the non-existent AgentState, but it seems that if a JVM doesn't have an AgentState, it would forever remain in the DB.

So, I've created a method to sweep the JVM without an AgentState.

Please review the PR and provide your feedback.