### PR TITLE
Use Gradle JVM toolchain and exclude old agent from building

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,8 @@ release {
         version
     }
 
-    pushReleaseVersionBranch.set("release/${ releaseVersion }")
-    tagTemplate.set("v${ releaseVersion }")
+    pushReleaseVersionBranch.set("release/${releaseVersion}")
+    tagTemplate.set("v${releaseVersion}")
     preTagCommitMessage.set("Release ")
     newVersionCommitMessage.set("Update next development version after Release")
     with(git) {
@@ -39,5 +39,13 @@ release {
 subprojects {
     tasks.withType<Test> {
         useJUnitPlatform()
+    }
+}
+
+project(":scavenger-old-agent-java").afterEvaluate {
+    tasks.all {
+        onlyIf {
+            project.hasProperty("oldAgent")
+        }
     }
 }

--- a/scavenger-agent-java/build.gradle.kts
+++ b/scavenger-agent-java/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 }
 
 java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+
     withJavadocJar()
     withSourcesJar()
 }
@@ -52,11 +56,6 @@ tasks.check {
 tasks.test {
     useJUnitPlatform()
     dependsOn(":scavenger-demo:build")
-}
-
-tasks.withType<JavaCompile> {
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
 }
 
 repositories {

--- a/scavenger-api/build.gradle.kts
+++ b/scavenger-api/build.gradle.kts
@@ -54,10 +54,13 @@ configure<DependencyManagementExtension> {
     }
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "11"
     }
 }
 

--- a/scavenger-collector/build.gradle.kts
+++ b/scavenger-collector/build.gradle.kts
@@ -68,10 +68,13 @@ configure<DependencyManagementExtension> {
     }
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "11"
     }
 }
 

--- a/scavenger-demo-extension/build.gradle.kts
+++ b/scavenger-demo-extension/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     kotlin("plugin.spring") version "1.8.10"
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
-
 repositories {
     mavenCentral()
 }
@@ -16,10 +14,13 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "11"
     }
 }
 

--- a/scavenger-demo/build.gradle.kts
+++ b/scavenger-demo/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
     kotlin("plugin.spring") version "1.8.10"
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
-
 repositories {
     mavenCentral()
 }
@@ -30,10 +28,13 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
+kotlin {
+    jvmToolchain(11)
+}
+
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "11"
     }
 }
 

--- a/scavenger-entity/build.gradle.kts
+++ b/scavenger-entity/build.gradle.kts
@@ -11,6 +11,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc:2.5.12")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/scavenger-model/build.gradle.kts
+++ b/scavenger-model/build.gradle.kts
@@ -1,9 +1,4 @@
-import com.google.protobuf.gradle.builtins
-import com.google.protobuf.gradle.generateProtoTasks
-import com.google.protobuf.gradle.id
-import com.google.protobuf.gradle.plugins
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
+import com.google.protobuf.gradle.*
 
 plugins {
     java
@@ -24,9 +19,8 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 }
 
-tasks.withType<JavaCompile> {
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
+kotlin {
+    jvmToolchain(8)
 }
 
 protobuf {

--- a/scavenger-schema/build.gradle.kts
+++ b/scavenger-schema/build.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
     java
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}


### PR DESCRIPTION
- Gradle handles required JDK version automatically regardless of the local Java version.
- Excludes the building of `scavenger-old-agent-java` when `./gradlew build` is run. `-PoldAgent` option can be used to re-include the subproject.