### PR TITLE
Set the maximum length of the content at the session layer

### DIFF
--- a/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/config/ArmeriaConfiguration.kt
+++ b/scavenger-collector/src/main/kotlin/com/navercorp/scavenger/config/ArmeriaConfiguration.kt
@@ -43,14 +43,16 @@ class ArmeriaConfiguration(
     @Bean
     fun armeriaServiceInitializer(tomcatService: TomcatService): ArmeriaServerConfigurator {
         return ArmeriaServerConfigurator { serviceBuilder: ServerBuilder ->
+            val maxMessageSize = maxMessageSize.toBytes().toInt()
             serviceBuilder.service("prefix:/", tomcatService)
                 .service(GrpcService.builder()
                     .addService(grpcAgentController)
                     .addExceptionMapping(IllegalArgumentException::class.java, Status.INVALID_ARGUMENT)
                     .addExceptionMapping(LicenseKeyNotFoundException::class.java, Status.UNAUTHENTICATED)
-                    .maxRequestMessageLength(maxMessageSize.toBytes().toInt())
+                    .maxRequestMessageLength(maxMessageSize)
                     .build()
                 )
+                .maxRequestLength(maxMessageSize.toLong())
         }
     }
 }


### PR DESCRIPTION
resolved: #86

The request stream is converted to a `DecodedHttpRequest`, which is checked for `maxRequestLength`. 
After that, the grpc service called `FramedGrpcService` checks it with `RequestMessageLength` and then it passes it to our grpcController.