### PR TITLE
Implement package name case sensitive

### DIFF
--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/service/SnapshotNodeService.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/service/SnapshotNodeService.kt
@@ -129,11 +129,11 @@ class SnapshotNodeService(
         val lastElement = elements.last()
         lastElement["signature"] = "${lastElement["signature"]}($arguments" + if (arguments.last() != ')') ")" else ""
 
-        elements.asReversed().forEachIndexed { index, mutableMap ->
+        elements.forEachIndexed { index, mutableMap ->
             val signature = checkNotNull(mutableMap["signature"]) { "signature must be not null" }
             mutableMap["type"] = if (signature.contains("(")) {
                 Node.Type.METHOD.name
-            } else if (signature.contains("$") || checkNotNull(elements[elements.size - index]["signature"]).contains("[($]".toRegex())) {
+            } else if (signature.contains("$") || checkNotNull(elements[index + 1]["signature"]).contains("[($]".toRegex())) {
                 Node.Type.CLASS.name
             } else {
                 Node.Type.PACKAGE.name

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/service/SnapshotNodeService.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/service/SnapshotNodeService.kt
@@ -129,8 +129,7 @@ class SnapshotNodeService(
         val lastElement = elements.removeLast()
         elements.add(SignatureWithType("${lastElement.signature}($arguments" + if (arguments.last() != ')') ")" else ""))
 
-
-        elements.forEachIndexed{index, signatureWithType ->
+        elements.forEachIndexed { index, signatureWithType ->
             val signature = signatureWithType.signature
             signatureWithType.type = if (signature.contains("(")) {
                 Node.Type.METHOD


### PR DESCRIPTION
#93 

The standard that seperate `method`, `class`, `package` as follows
```
1. if contains `(`, it's method.
  - Because the signature is taken from methodInvocationTable. 
  - I think always last element is method.
2. if contains `$`, it's (inner) class
3. if next element is `(`(method) or `$`(inner class), it is class.
4. Otherwise, it's package
```

![image](https://github.com/naver/scavenger/assets/122586083/a45bd1e1-7b3d-4393-af1c-78762fb37d46)
