### PR TITLE
Modify snapshot_nodes table's signature type to text

### DIFF
--- a/scavenger-schema/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/scavenger-schema/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,5 +2,7 @@ databaseChangeLog:
   - include:
       file: db/changelog/schema.sql
   - include:
+      file: db/changelog/schema-1.1.2.sql
+  - include:
       file: db/changelog/test-data-set.sql
       context: local

--- a/scavenger-schema/src/main/resources/db/changelog/schema-1.1.2.sql
+++ b/scavenger-schema/src/main/resources/db/changelog/schema-1.1.2.sql
@@ -1,0 +1,3 @@
+--changeset scavenger:3
+
+ALTER TABLE snapshot_nodes MODIFY signature TEXT;

--- a/scavenger-schema/src/main/resources/db/changelog/schema.sql
+++ b/scavenger-schema/src/main/resources/db/changelog/schema.sql
@@ -181,3 +181,8 @@ CREATE TABLE IF NOT EXISTS `leadership` (
     memberId   VARCHAR(128)   NOT NULL,
     lastSeenActive TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) COLLATE = utf8mb4_0900_as_cs;
+
+
+--changeset scavenger:3
+
+ALTER TABLE snapshot_nodes MODIFY signature TEXT;

--- a/scavenger-schema/src/main/resources/db/changelog/schema.sql
+++ b/scavenger-schema/src/main/resources/db/changelog/schema.sql
@@ -181,8 +181,3 @@ CREATE TABLE IF NOT EXISTS `leadership` (
     memberId   VARCHAR(128)   NOT NULL,
     lastSeenActive TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) COLLATE = utf8mb4_0900_as_cs;
-
-
---changeset scavenger:3
-
-ALTER TABLE snapshot_nodes MODIFY signature TEXT;


### PR DESCRIPTION
#95 
Change `snapshot_nodes` table's `signature` column type to `text`.
And add test data
![image](https://github.com/naver/scavenger/assets/122586083/c1411c0d-6a90-4490-92cb-a1ac6af0de64)
