### PR TITLE
Support JDK 21

### DIFF
--- a/scavenger-agent-java/build.gradle.kts
+++ b/scavenger-agent-java/build.gradle.kts
@@ -62,9 +62,9 @@ repositories {
 
 dependencies {
     implementation(project(":scavenger-model"))
-    implementation("net.bytebuddy:byte-buddy:1.12.23")
-    implementation("org.ow2.asm:asm:9.4")
-    implementation("org.ow2.asm:asm-tree:9.4")
+    implementation("net.bytebuddy:byte-buddy:1.14.3")
+    implementation("org.ow2.asm:asm:9.5")
+    implementation("org.ow2.asm:asm-tree:9.5")
     implementation("com.squareup.okhttp3:okhttp:3.14.9")
     implementation("com.google.protobuf:protobuf-java-util:${property("protobufVersion")}")
     implementation("io.grpc:grpc-stub:${property("grpcVersion")}")
@@ -107,7 +107,7 @@ tasks.named<Test>("integrationTest") {
 
     systemProperty("integrationTest.scavengerAgent", tasks.shadowJar.get().outputs.files.asPath)
     systemProperty("integrationTest.classpath", "build/classes/java/integrationTest:$integrationTestRuntimeClasspath")
-    systemProperty("integrationTest.javaPaths", javaPaths(8, 11, 17))
+    systemProperty("integrationTest.javaPaths", javaPaths(8, 11, 17, 21))
 }
 
 tasks.withType<ProcessResources> {


### PR DESCRIPTION
resolved: #97 

- ASM v9.5 supports to JDK 21 
  - ASM Versions: https://asm.ow2.io/versions.html
- ByteBuddy v1.14.3 uses ASM v9.5
  - https://github.com/raphw/byte-buddy/compare/byte-buddy-1.14.2...byte-buddy-1.14.3

![image](https://github.com/naver/scavenger/assets/122586083/7ce0d572-c8a4-483d-ad3e-4c8a8ddfffe0)
