### PR TITLE
Fix implicit dependencies between tasks

### DIFF
--- a/scavenger-agent-java/build.gradle.kts
+++ b/scavenger-agent-java/build.gradle.kts
@@ -98,6 +98,7 @@ val integrationTestRuntimeClasspath = configurations.named("integrationTestRunti
 
 tasks.named<Test>("integrationTest") {
     dependsOn(tasks.shadowJar)
+    mustRunAfter(tasks.jar)
     shouldRunAfter(tasks.test)
     useJUnitPlatform()
 


### PR DESCRIPTION
Integration Test was disabled when run scavenger-agent-java:build that triggered by PR builder.
To solove this problem, we can use 'mustRunAfter' to specify the order between 'jar' and 'integrationTest' tasks.

https://github.com/naver/scavenger/actions/runs/6860169774/job/18653556996#step:5:102
> Execution optimizations have been disabled for task ':scavenger-agent-java:integrationTest' to ensure correctness due to the following reasons:
>  - Gradle detected a problem with the following location: '/home/runner/work/scavenger/scavenger/scavenger-agent-java/build/libs/scavenger-agent-java-1.1.1-SNAPSHOT.jar'. Reason: Task ':scavenger-agent-java:integrationTest' uses this output of task ':scavenger-agent-java:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
