### PR TITLE
Add foojay resolver plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,7 @@ include("scavenger-old-model")
 include("scavenger-demo")
 include("scavenger-demo-extension")
 include("scavenger-frontend")
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
+}


### PR DESCRIPTION
Add the foojay-resolver plugin to automatically install the JDK if it is not installed at build time.
https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories