### PR TITLE
Modify extract version regexp in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
       - name: Extract tag version
-        run: echo "tag=$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "tag=$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-p[0-9]+)?')" >> $GITHUB_OUTPUT
         id: extract_tag_version
       - name: Build project
         run: ./gradlew clean build

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_ACTIONS_TOKEN }}
       - name: Extract version
-        run: echo "version=$(echo '${{ github.event.pull_request.title }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo '${{ github.event.pull_request.title }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(-p[0-9]+)?')" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Set git config
         run: |


### PR DESCRIPTION
The patch release has also been changed to enable github actions.

<img width="1174" alt="image" src="https://github.com/naver/scavenger/assets/122586083/5f01dcef-190d-4518-be6c-608593752d8d">
