### PR TITLE
Fix README.md contribution default branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can find the user guide at the following location link.
 Scavenger welcomes any contributions from users.<br/>
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from master.
+1. Fork the repo and create your branch from develop.
 2. If you've added code that should be tested, add tests.
 3. Ensure the test suite passes.
 4. Issue that pull request!


### PR DESCRIPTION
Fixed default branch name in README.md, contibution.

Because default branch is develop, I think we should create feature branch from develop.