### PR TITLE
Bump up Gradle 8.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ subprojects {
 }
 
 project(":scavenger-old-agent-java").afterEvaluate {
-    tasks.all {
+    tasks.configureEach {
         onlyIf {
             project.hasProperty("oldAgent")
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/scavenger-agent-java/build.gradle.kts
+++ b/scavenger-agent-java/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
     java
     `maven-publish`
     signing
-    id("com.github.johnrengelman.shadow") version "7.0.0"
-    id("io.freefair.lombok") version "6.6.3"
-    id("org.unbroken-dome.test-sets") version "4.0.0"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
+    id("io.freefair.lombok") version "8.6"
+    id("org.unbroken-dome.test-sets") version "4.1.0"
 }
 
 java {
@@ -77,7 +77,7 @@ dependencies {
 }
 
 testSets {
-    create("integrationTest")
+    register("integrationTest")
 }
 
 dependencies {
@@ -104,7 +104,7 @@ tasks.named<Test>("integrationTest") {
 
     inputs.files(file("build.gradle.kts"))
     inputs.files(tasks.shadowJar.get().outputs.files)
-    outputs.dir(file("$buildDir/test-results/integrationTest"))
+    outputs.dir(layout.buildDirectory.dir("test-results/integrationTest").get().asFile)
 
     systemProperty("integrationTest.scavengerAgent", tasks.shadowJar.get().outputs.files.asPath)
     systemProperty("integrationTest.classpath", "build/classes/java/integrationTest:$integrationTestRuntimeClasspath")

--- a/scavenger-old-agent-java/build.gradle.kts
+++ b/scavenger-old-agent-java/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
     java
     `maven-publish`
     signing
-    id("io.freefair.lombok") version "6.5.1"
-    id("com.github.johnrengelman.shadow") version "7.0.0"
-    id("org.unbroken-dome.test-sets") version "4.0.0"
+    id("io.freefair.lombok") version "8.6"
+    id("com.github.johnrengelman.shadow") version "8.0.0"
+    id("org.unbroken-dome.test-sets") version "4.1.0"
 }
 
 repositories {
@@ -114,7 +114,7 @@ val javaPath = { version: Int ->
 }
 
 testSets {
-    create("integrationTest")
+    register("integrationTest")
 }
 
 dependencies {
@@ -139,8 +139,7 @@ tasks.named<Test>("integrationTest") {
 
     inputs.files(file("build.gradle.kts"))
     inputs.files(tasks.shadowJar.get().outputs.files)
-    // inputs.files (sourceSets.integrationTest.output)
-    outputs.dir(file("$buildDir/test-results/integrationTest"))
+    outputs.dir(layout.buildDirectory.dir("test-results/integrationTest").get().asFile)
 
     systemProperty("integrationTest.codekvastAgent", tasks.shadowJar.get().outputs.files.asPath)
     systemProperty("integrationTest.classpath", "build/classes/java/integrationTest:$integrationTestRuntimeClasspath")

--- a/scavenger-old-model/build.gradle.kts
+++ b/scavenger-old-model/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     id("org.gradle.idea")
     id("com.adarshr.test-logger") version "3.0.0"
-    id("io.freefair.lombok") version "6.5.1"
+    id("io.freefair.lombok") version "8.6"
 }
 
 dependencies {


### PR DESCRIPTION
related to #131 
Bump up Gradle from 7.6 to 8.9

### Changes
- `all` -> `configureEach`
  - https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#eager_apis_to_avoid
- `com.github.johnrengelman.shadow` 7 -> 8
  - https://github.com/johnrengelman/shadow?tab=readme-ov-file#latest-test-compatibility
- `io.freefair.lombok` 6.x -> 8.6
  - https://github.com/freefair/gradle-plugins?tab=readme-ov-file#compatibility-matrix
- `org.unbroken-dome.test-sets` 4 -> 4.1
  - https://github.com/unbroken-dome/gradle-testsets-plugin/releases/tag/v4.1.0
- Use `register` instead of `create`
  - https://github.com/gradle/gradle/blob/6b2aec40ae4ed356da57c57a03d79b726d326626/platforms/documentation/docs/src/docs/userguide/authoring-builds/tasks/task_configuration_avoidance.adoc#defer-task-creation
- Deprecated `buildDir`
  - https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir