### PR TITLE
Bump up actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -35,7 +35,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew :scavenger-agent-java:clean scavenger-agent-java:build
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: scavenger-agent-java
@@ -62,7 +62,7 @@ jobs:
         run: ./gradlew :scavenger-collector:clean scavenger-collector:build
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scavenger-collector
           path: scavenger-collector/build/test-results
@@ -88,7 +88,7 @@ jobs:
         run: ./gradlew :scavenger-api:clean scavenger-api:build
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scavenger-api
           path: scavenger-api/build/test-results


### PR DESCRIPTION
Like belows, github actions failed becuz it uses a deprecated version of `actions/upload-artifact:v2`
So bump up `actions/upload-artifact` to v4

https://github.com/naver/scavenger/actions/runs/11305196768/job/31478254577?pr=134