### PR TITLE
Replace MethodNode.parameters usage with Type.getArgumentTypes

### DIFF
--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/model/Method.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/model/Method.java
@@ -66,7 +66,7 @@ public class Method {
     private boolean isGetter(MethodNode methodNode) {
         Type returnType = Type.getReturnType(methodNode.desc);
 
-        return (methodNode.parameters == null || methodNode.parameters.isEmpty())
+        return Type.getArgumentTypes(methodNode.desc).length == 0
             && returnType != Type.VOID_TYPE && (methodNode.name.startsWith("get")
             || (methodNode.name.startsWith("is") && returnType == Type.BOOLEAN_TYPE)
             || (methodNode.name.matches("component\\d+")) // kotlin component
@@ -75,8 +75,7 @@ public class Method {
 
     private boolean isSetter(MethodNode methodNode) {
         return methodNode.name.startsWith("set")
-            && methodNode.parameters != null
-            && methodNode.parameters.size() == 1
+            && Type.getArgumentTypes(methodNode.desc).length == 1
             && Type.getReturnType(methodNode.desc) == Type.VOID_TYPE;
     }
 


### PR DESCRIPTION
related to #139 

Replace usage of `MethodNode.parameters` with `Type.getArgumentTypes(methodNode.desc)`.
The code will work reliably in production environments where debug symbols may be stripped.