### PR TITLE
Update OSSRH URL

### DIFF
--- a/scavenger-agent-java/build.gradle.kts
+++ b/scavenger-agent-java/build.gradle.kts
@@ -190,9 +190,9 @@ publishing {
             }
             name = "OSSRH"
             url = if (version.toString().endsWith("-SNAPSHOT")) {
-                uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                uri("https://central.sonatype.com/repository/maven-snapshots/")
             } else {
-                uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
             }
         }
     }

--- a/scavenger-old-agent-java/build.gradle.kts
+++ b/scavenger-old-agent-java/build.gradle.kts
@@ -210,9 +210,9 @@ publishing {
             }
             name = "OSSRH"
             url = if (version.toString().endsWith("-SNAPSHOT")) {
-                uri("https://oss.sonatype.org/content/repositories/snapshots/")
+                uri("https://central.sonatype.com/repository/maven-snapshots/")
             } else {
-                uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
             }
         }
     }


### PR DESCRIPTION
Migrate OSSRH URLs to the new staging API.


- refer: 
  - snapshot: https://central.sonatype.org/publish/publish-portal-snapshots/#consuming-via-gradle
  - release: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuring-the-repository