### PR TITLE
Fix agent hash mismatch when method declares throws

### DIFF
--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistry.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistry.java
@@ -50,6 +50,12 @@ public class MethodRegistry {
                 isParenthesisFound = true;
             }
         }
-        return byteBuddySignature.substring(begin, end);
+        String signature = byteBuddySignature.substring(begin, end);
+        int throwsIndex = signature.indexOf(" throws ");
+        if (throwsIndex >= 0) {
+            return signature.substring(0, throwsIndex);
+        }
+
+        return signature;
     }
 }

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistry.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistry.java
@@ -50,12 +50,7 @@ public class MethodRegistry {
                 isParenthesisFound = true;
             }
         }
-        String signature = byteBuddySignature.substring(begin, end);
-        int throwsIndex = signature.indexOf(" throws ");
-        if (throwsIndex >= 0) {
-            return signature.substring(0, throwsIndex);
-        }
-
-        return signature;
+        int throwsIndex = byteBuddySignature.indexOf(" throws ", begin);
+        return byteBuddySignature.substring(begin, throwsIndex >= 0 ? throwsIndex : end);
     }
 }

--- a/scavenger-agent-java/src/test/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistryTest.java
+++ b/scavenger-agent-java/src/test/java/com/navercorp/scavenger/javaagent/collecting/MethodRegistryTest.java
@@ -47,4 +47,10 @@ public class MethodRegistryTest {
                 .isEqualTo("sample.app.NotServiceClass.doNothing()");
     }
 
+    @Test
+    void extractSignatureWithThrows() {
+        assertThat(
+            MethodRegistry.extractSignature("public static void sample.app.NotServiceClass.doNothing() throws RuntimeException"))
+            .isEqualTo("sample.app.NotServiceClass.doNothing()");
+    }
 }


### PR DESCRIPTION
안녕하세요.

데드코드 분석을 위한 scavenger 테스트 진행 중에 문제를 발견해서 수정하고 PR 드립니다.

### 이슈
메서드가 분명히 호출되었음에도 scavenger 대시보드에서 몇몇 메서드는 확인되지 않는 현상 발견했습니다.
agent 에서 debugMode를 켜고 메서드 호출시 invoke 되었다는 로그로 확인했습니다.

여러가지 시도로도 해결되지 않아 agent-java MethodRegistry를 확인해보니 `static String extractSignature(String byteBuddySignature)` 메서드에서 throws 절까지 포함한 시그니처를 해싱해서 codeBase 해싱값과 일치하지 않는 케이스가 있을 수 있다는 것을 확인했습니다.

### 해결
`static String extractSignature(String byteBuddySignature)` 에서 throws 이하를 제거해 codeBase에서 생성한 값과 일치하도록 수정했습니다.

실제 대시보드에서도 정상 동작 확인했습니다.

### 테스트
extractSignatureWithThrows 테스트를 추가했고 ./gradlew test 로 테스트 진행하였습니다.

좋은 툴을 개발해주셔서 감사합니다 👍👍👍
검토 부탁드립니다 ( _ _ ) 