### PR TITLE
Fix gRPC UNAVAILABLE error

### DIFF
--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
@@ -32,11 +32,11 @@ public class GrpcClient implements AutoCloseable {
     private ManagedChannel channel;
     private GrpcAgentServiceGrpc.GrpcAgentServiceBlockingStub stub;
 
-    public static GrpcClient plaintext(String host) {
+    public static GrpcClient createPlaintext(String host) {
         return new GrpcClient(host, false);
     }
 
-    public static GrpcClient tls(String host) {
+    public static GrpcClient createTls(String host) {
         return new GrpcClient(host, true);
     }
 

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
@@ -7,12 +7,11 @@ import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.navercorp.scavenger.model.CallStackDataPublication;
-
 import io.grpc.ManagedChannel;
 import io.grpc.okhttp.OkHttpChannelBuilder;
 import lombok.extern.java.Log;
 
+import com.navercorp.scavenger.model.CallStackDataPublication;
 import com.navercorp.scavenger.model.CodeBasePublication;
 import com.navercorp.scavenger.model.GetConfigRequest;
 import com.navercorp.scavenger.model.GetConfigResponse;
@@ -29,14 +28,14 @@ public class GrpcClient implements AutoCloseable {
     private static final Pattern DATA_SIZE_PATTERN = Pattern.compile("^([+\\-]?\\d+)([a-zA-Z]{0,2})$");
 
     private final String host;
-
+    private final boolean useTls;
     private ManagedChannel channel;
     private GrpcAgentServiceGrpc.GrpcAgentServiceBlockingStub stub;
 
-    public GrpcClient(String host) {
-        log.info("[scavenger] creating new grpc client. host is " + host);
+    public GrpcClient(String host, boolean useTls) {
+        log.info("[scavenger] creating new grpc client. host is " + host + " tls=" + useTls);
         this.host = host;
-
+        this.useTls = useTls;
         createNewChannelIfShutdown();
     }
 
@@ -98,10 +97,16 @@ public class GrpcClient implements AutoCloseable {
     }
 
     private ManagedChannel createChannel(int maxMessageSize) {
-        return OkHttpChannelBuilder.forTarget(this.host)
-            .maxInboundMessageSize(maxMessageSize)
-            .usePlaintext()
-            .build();
+        OkHttpChannelBuilder okHttpChannelBuilder = OkHttpChannelBuilder.forTarget(this.host)
+            .maxInboundMessageSize(maxMessageSize);
+
+        if (useTls) {
+            okHttpChannelBuilder.useTransportSecurity();
+        } else {
+            okHttpChannelBuilder.usePlaintext();
+        }
+
+        return okHttpChannelBuilder.build();
     }
 
     private int maxMessageSize() {

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java
@@ -32,7 +32,15 @@ public class GrpcClient implements AutoCloseable {
     private ManagedChannel channel;
     private GrpcAgentServiceGrpc.GrpcAgentServiceBlockingStub stub;
 
-    public GrpcClient(String host, boolean useTls) {
+    public static GrpcClient plaintext(String host) {
+        return new GrpcClient(host, false);
+    }
+
+    public static GrpcClient tls(String host) {
+        return new GrpcClient(host, true);
+    }
+
+    private GrpcClient(String host, boolean useTls) {
         log.info("[scavenger] creating new grpc client. host is " + host + " tls=" + useTls);
         this.host = host;
         this.useTls = useTls;

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
@@ -90,7 +90,8 @@ public class Publisher {
     private GrpcClient getGrpcClient() {
         if (grpcClient == null) {
             boolean useTls = config.getServerUrl().startsWith("https://");
-            grpcClient = new GrpcClient(getInitConfigResponse().getCollectorUrl(), useTls);
+            String collectorUrl = getInitConfigResponse().getCollectorUrl();
+            grpcClient = useTls ? GrpcClient.tls(collectorUrl) : GrpcClient.plaintext(collectorUrl);
         }
 
         return grpcClient;

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
@@ -8,9 +8,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import com.google.protobuf.util.JsonFormat;
-
-import com.navercorp.scavenger.model.CallStackDataPublication;
-
 import lombok.extern.java.Log;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -19,6 +16,7 @@ import okhttp3.Response;
 
 import com.navercorp.scavenger.javaagent.model.Config;
 import com.navercorp.scavenger.javaagent.util.Constants;
+import com.navercorp.scavenger.model.CallStackDataPublication;
 import com.navercorp.scavenger.model.CodeBasePublication;
 import com.navercorp.scavenger.model.GetConfigRequest;
 import com.navercorp.scavenger.model.GetConfigResponse;
@@ -91,7 +89,8 @@ public class Publisher {
 
     private GrpcClient getGrpcClient() {
         if (grpcClient == null) {
-            grpcClient = new GrpcClient(getInitConfigResponse().getCollectorUrl());
+            boolean useTls = config.getServerUrl().startsWith("https://");
+            grpcClient = new GrpcClient(getInitConfigResponse().getCollectorUrl(), useTls);
         }
 
         return grpcClient;

--- a/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
+++ b/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/Publisher.java
@@ -91,7 +91,7 @@ public class Publisher {
         if (grpcClient == null) {
             boolean useTls = config.getServerUrl().startsWith("https://");
             String collectorUrl = getInitConfigResponse().getCollectorUrl();
-            grpcClient = useTls ? GrpcClient.tls(collectorUrl) : GrpcClient.plaintext(collectorUrl);
+            grpcClient = useTls ? GrpcClient.createTls(collectorUrl) : GrpcClient.createPlaintext(collectorUrl);
         }
 
         return grpcClient;


### PR DESCRIPTION
https://github.com/naver/scavenger/issues/78 와 동일한 `StatusRuntimeException: UNAVAILABLE` 문제를 겪고 있었고,
여러 가지로 확인해보다가 원인으로 보이는 부분을 수정해봤더니 문제가 재현되지 않아 PR 보냅니다.

## 환경
- 쿠버네티스 환경
- Scavenger Agent → [plaintext gRPC] → Ingress L7 (ALB, HTTPS)

## 확인한 사항
- HTTPS 통신은 서비스 <-> collector 간 문제 없이 동작
- gRPC는 reflection이 꺼져 있어서 proto를 직접 지정해 호출해보니 정상적으로 통신됨  
→ 네트워크나 단순 연결 문제는 아닌 것으로 판단했습니다.

## 원인
Ingress(L7)가 HTTPS(TLS) 연결을 기대하는 상태에서 Agent는 `usePlaintext()` 설정으로 평문 gRPC 요청을 보내고 있었습니다. 

https://github.com/naver/scavenger/blob/c0fcd76c9a819a504b5ad2052e170be7baa7f174/scavenger-agent-java/src/main/java/com/navercorp/scavenger/javaagent/publishing/GrpcClient.java#L100-L104

이 구성에서는 TLS Handshake가 성립되지 않아 연결이 즉시 종료되고 그로인해 Agent에서는 스트림이 비정상 종료된 것으로 인식되어 `UNAVAILABLE` 에러가 발생하는 것이 아닐까? 하고 가정했습니다.

## 해결
- Collector URL이 HTTPS인 경우(TLS 사용), gRPC 클라이언트가 `usePlaintext()` 대신 `useTransportSecurity()`를 사용하도록 조건 분기 추가

## 테스트
- 동일한 환경(Scavenger Agent → [plaintext gRPC] → Ingress L7 (ALB, HTTPS))에서 재현 확인
- 수정 적용 후, 동일 조건에서 `StatusRuntimeException: UNAVAILABLE` 발생하지 않음을 확인
- gRPC 스트림이 정상적으로 유지되는 것 확인