### PR TITLE
Add MCP authentication and envelope (#170 phase 1)

### DIFF
--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/ScavengerApiApplication.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/ScavengerApiApplication.kt
@@ -2,8 +2,10 @@ package com.navercorp.scavenger
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 
 @SpringBootApplication
+@EnableAspectJAutoProxy(exposeProxy = true)
 class ScavengerApiApplication
 
 fun main(args: Array<String>) {

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/config/WebConfig.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/config/WebConfig.kt
@@ -1,5 +1,6 @@
 package com.navercorp.scavenger.config
 
+import com.navercorp.scavenger.mcp.ApiKeyAuthInterceptor
 import org.slf4j.MDC
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -14,9 +15,13 @@ import jakarta.servlet.http.HttpServletResponse
 
 @EnableWebMvc
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(
+    private val apiKeyAuthInterceptor: ApiKeyAuthInterceptor
+) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(MdcLoggingInterceptor())
+        registry.addInterceptor(apiKeyAuthInterceptor)
+            .addPathPatterns("/mcp", "/mcp/**")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/dto/McpError.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/dto/McpError.kt
@@ -1,0 +1,18 @@
+package com.navercorp.scavenger.dto
+
+data class McpError(
+    val code: Code,
+    val message: String,
+    val hint: String? = null,
+    val retryable: Boolean = false
+) {
+    enum class Code {
+        AUTH_MISSING,
+        AUTH_INVALID,
+        METHOD_NOT_FOUND,
+        SNAPSHOT_NOT_READY,
+        INVALID_ARGUMENT,
+        REFRESH_FAILED,
+        INTERNAL_ERROR
+    }
+}

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/dto/McpResponse.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/dto/McpResponse.kt
@@ -1,0 +1,13 @@
+package com.navercorp.scavenger.dto
+
+data class McpResponse<out T>(
+    val ok: Boolean,
+    val data: T? = null,
+    val error: McpError? = null
+) {
+    companion object {
+        fun <T> success(data: T): McpResponse<T> = McpResponse(ok = true, data = data)
+
+        fun failure(error: McpError): McpResponse<Nothing> = McpResponse(ok = false, error = error)
+    }
+}

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/mcp/ApiKeyAuthInterceptor.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/mcp/ApiKeyAuthInterceptor.kt
@@ -1,0 +1,62 @@
+package com.navercorp.scavenger.mcp
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.navercorp.scavenger.dto.McpError
+import com.navercorp.scavenger.dto.McpResponse
+import com.navercorp.scavenger.repository.CustomerRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class ApiKeyAuthInterceptor(
+    private val customerRepository: CustomerRepository,
+    private val objectMapper: ObjectMapper,
+) : HandlerInterceptor, Ordered {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE + 100
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val licenseKey = request.getHeader(McpAuthContext.HEADER_LICENSE_KEY)
+        if (licenseKey.isNullOrBlank()) {
+            return reject(response, MISSING_KEY_ERROR)
+        }
+
+        val customer = customerRepository.findByLicenseKey(licenseKey).orElse(null)
+        if (customer == null) {
+            logger.warn { "MCP auth rejected: unknown licenseKey suffix=${licenseKey.takeLast(4)}" }
+            return reject(response, INVALID_KEY_ERROR)
+        }
+
+        request.setAttribute(McpAuthContext.ATTRIBUTE_CUSTOMER_ID, customer.id)
+        return true
+    }
+
+    private fun reject(response: HttpServletResponse, error: McpError): Boolean {
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        objectMapper.writeValue(response.writer, McpResponse.failure(error))
+        return false
+    }
+
+    companion object {
+        private val MISSING_KEY_ERROR = McpError(
+            code = McpError.Code.AUTH_MISSING,
+            message = "${McpAuthContext.HEADER_LICENSE_KEY} header is required.",
+            hint = "Set the header to your Scavenger licenseKey in your MCP client config.",
+        )
+        private val INVALID_KEY_ERROR = McpError(
+            code = McpError.Code.AUTH_INVALID,
+            message = "Invalid licenseKey.",
+            hint = "Verify the licenseKey value against the Scavenger workspace.",
+        )
+    }
+}

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/mcp/McpAuthContext.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/mcp/McpAuthContext.kt
@@ -1,0 +1,14 @@
+package com.navercorp.scavenger.mcp
+
+import jakarta.servlet.http.HttpServletRequest
+
+object McpAuthContext {
+    const val ATTRIBUTE_CUSTOMER_ID = "scavenger.mcp.customerId"
+    const val HEADER_LICENSE_KEY = "X-Scavenger-License-Key"
+}
+
+fun HttpServletRequest.requireCustomerId(): Long {
+    val attr = getAttribute(McpAuthContext.ATTRIBUTE_CUSTOMER_ID)
+        ?: error("MCP customerId not present on request — ApiKeyAuthInterceptor must run first")
+    return attr as? Long ?: error("Expected Long for ${McpAuthContext.ATTRIBUTE_CUSTOMER_ID} but got ${attr::class}")
+}

--- a/scavenger-api/src/main/kotlin/com/navercorp/scavenger/repository/CustomerRepository.kt
+++ b/scavenger-api/src/main/kotlin/com/navercorp/scavenger/repository/CustomerRepository.kt
@@ -10,4 +10,6 @@ interface CustomerRepository : DelegatableJdbcRepository<CustomerEntity, Long> {
     fun findAllByGroupId(groupId: String): List<CustomerEntity>
 
     fun findByNameAndGroupId(name: String, groupId: String): Optional<CustomerEntity>
+
+    fun findByLicenseKey(licenseKey: String): Optional<CustomerEntity>
 }

--- a/scavenger-api/src/test/kotlin/com/navercorp/scavenger/mcp/ApiKeyAuthInterceptorTest.kt
+++ b/scavenger-api/src/test/kotlin/com/navercorp/scavenger/mcp/ApiKeyAuthInterceptorTest.kt
@@ -1,0 +1,80 @@
+package com.navercorp.scavenger.mcp
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.navercorp.scavenger.dto.McpError
+import com.navercorp.scavenger.dto.McpResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+@SpringBootTest
+class ApiKeyAuthInterceptorTest {
+    @Autowired
+    private lateinit var sut: ApiKeyAuthInterceptor
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `preHandle injects customerId when licenseKey is valid`() {
+        val request = MockHttpServletRequest().apply {
+            addHeader(McpAuthContext.HEADER_LICENSE_KEY, "4c94e0dd-ad04-4b17-9238-f46bba75c684")
+        }
+        val response = MockHttpServletResponse()
+
+        val result = sut.preHandle(request, response, Any())
+
+        assertThat(result).isTrue
+        assertThat(request.getAttribute(McpAuthContext.ATTRIBUTE_CUSTOMER_ID)).isEqualTo(1L)
+        assertThat(response.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `preHandle rejects with AUTH_MISSING when header is absent`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+
+        val result = sut.preHandle(request, response, Any())
+
+        assertThat(result).isFalse
+        assertThat(response.status).isEqualTo(401)
+        assertErrorCode(response, McpError.Code.AUTH_MISSING)
+    }
+
+    @Test
+    fun `preHandle rejects with AUTH_MISSING when header is blank`() {
+        val request = MockHttpServletRequest().apply {
+            addHeader(McpAuthContext.HEADER_LICENSE_KEY, "   ")
+        }
+        val response = MockHttpServletResponse()
+
+        val result = sut.preHandle(request, response, Any())
+
+        assertThat(result).isFalse
+        assertThat(response.status).isEqualTo(401)
+        assertErrorCode(response, McpError.Code.AUTH_MISSING)
+    }
+
+    @Test
+    fun `preHandle rejects with AUTH_INVALID when licenseKey is unknown`() {
+        val request = MockHttpServletRequest().apply {
+            addHeader(McpAuthContext.HEADER_LICENSE_KEY, "unknown-license-key")
+        }
+        val response = MockHttpServletResponse()
+
+        val result = sut.preHandle(request, response, Any())
+
+        assertThat(result).isFalse
+        assertThat(response.status).isEqualTo(401)
+        assertErrorCode(response, McpError.Code.AUTH_INVALID)
+    }
+
+    private fun assertErrorCode(response: MockHttpServletResponse, expected: McpError.Code) {
+        val body = objectMapper.readValue(response.contentAsString, McpResponse::class.java)
+        assertThat(body.ok).isFalse
+        assertThat(body.error?.code).isEqualTo(expected)
+    }
+}

--- a/scavenger-api/src/test/kotlin/com/navercorp/scavenger/repository/CustomerRepositoryTest.kt
+++ b/scavenger-api/src/test/kotlin/com/navercorp/scavenger/repository/CustomerRepositoryTest.kt
@@ -19,4 +19,18 @@ class CustomerRepositoryTest {
     fun findByNameAndGroupId() {
         assertThat(sut.findByNameAndGroupId("notExistCustomer", "default-group")).isEmpty
     }
+
+    @Test
+    fun `findByLicenseKey returns customer when key matches`() {
+        val result = sut.findByLicenseKey("4c94e0dd-ad04-4b17-9238-f46bba75c684")
+
+        assertThat(result).isPresent
+        assertThat(result.get().id).isEqualTo(1)
+        assertThat(result.get().name).isEqualTo("demo")
+    }
+
+    @Test
+    fun `findByLicenseKey returns empty when key is unknown`() {
+        assertThat(sut.findByLicenseKey("unknown-key")).isEmpty
+    }
 }

--- a/scavenger-api/src/test/kotlin/com/navercorp/scavenger/service/SnapshotServiceTest.kt
+++ b/scavenger-api/src/test/kotlin/com/navercorp/scavenger/service/SnapshotServiceTest.kt
@@ -2,10 +2,13 @@ package com.navercorp.scavenger.service
 
 import com.navercorp.scavenger.repository.SnapshotRepository
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 
 @SpringBootTest
 class SnapshotServiceTest {
@@ -15,11 +18,43 @@ class SnapshotServiceTest {
     @Autowired
     private lateinit var snapshotRepository: SnapshotRepository
 
+    @Autowired
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    private val txTemplate by lazy { TransactionTemplate(transactionManager) }
+
     @Test
     @Transactional
     fun deleteSnapshot() {
         sut.deleteSnapshot(1, 1)
 
         Assertions.assertThat(snapshotRepository.findByCustomerIdAndId(1, 1)).isNotPresent
+    }
+
+    @Test
+    fun `createSnapshot's saveSnapshotWithLimit commits via REQUIRES_NEW even when outer transaction rolls back`() {
+        val name = "aop-redirect-${System.currentTimeMillis()}"
+        try {
+            txTemplate.execute { status ->
+                sut.createSnapshot(
+                    customerId = 1,
+                    name = name,
+                    applicationIdList = listOf(1),
+                    environmentIdList = listOf(1),
+                    filterInvokedAtMillis = 0,
+                    packages = ""
+                )
+                status.setRollbackOnly()
+            }
+
+            val surviving = sut.listSnapshots(1).firstOrNull { it.name == name }
+            assertThat(surviving)
+                .describedAs("saveSnapshotWithLimit's @Transactional(REQUIRES_NEW) requires proxy(this) to route through the AOP proxy")
+                .isNotNull
+        } finally {
+            sut.listSnapshots(1)
+                .filter { it.name == name }
+                .forEach { sut.deleteSnapshot(1, requireNotNull(it.id)) }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #170 — **scope-reduced** after the 2026-05-20 redesign on #170 dropped the AI-managed snapshot model. This PR now lands only the foundation pieces that survive the redesign:

- License-key authentication for the `/mcp` endpoint
- Shared MCP response envelope and error model
- A small one-line fix to a long-standing AOP self-call bug uncovered during review

The AI-snapshot lifecycle (`AiSnapshotService`, async refresh, reserved-name handling, etc.) is **removed** from this PR. With the redesigned plan there is no `__ai__` snapshot at all — MCP tools will query `methods` / `invocations` / `call_stacks` directly. See [the redesign comment on #170](https://github.com/naver/scavenger/issues/170#issuecomment-4494193810) for the benchmark data and rationale.

## What this PR adds

### Authentication for `/mcp`
- `CustomerRepository.findByLicenseKey` (derived query)
- `ApiKeyAuthInterceptor` registered on `/mcp` and `/mcp/**`; resolves the `X-Scavenger-License-Key` header to a `customerId` and rejects requests with a sealed `McpError` body
- `mcp/McpAuthContext` — request-attribute key constants and `HttpServletRequest.requireCustomerId()` extension
- Cross-customer access attempts return a generic body (no existence leak)

### Shared response types
- `dto/McpError` (sealed code enum) and `dto/McpResponse<T>` envelope used by every MCP tool in later phases

### AOP self-call fix
- `@EnableAspectJAutoProxy(exposeProxy = true)` on `ScavengerApiApplication`
- Background: `SnapshotService.createSnapshot` already used `proxy(this).saveSnapshotWithLimit(...)` to invoke a `@Transactional(REQUIRES_NEW)` method on the same bean. Without `exposeProxy = true`, the `proxy(...)` helper's catch block silently returned the raw `this`, so the `REQUIRES_NEW` boundary was never applied. Adding the annotation makes the existing helper actually work — independent of MCP, and a fix the snapshot-count race relied on.
- Verified with a behavior-based test that runs the call inside an outer transaction set `rollbackOnly`. With the annotation, the inner write survives; without it (the prior production behavior), the inner write rolls back with the outer.

## Removed from this PR (compared to the original draft)

Per the #170 redesign:

- `AiSnapshotService`, `AiSnapshotRefresher`, `AiSnapshotState`
- `AsyncConfig` (`@EnableAsync` + MDC-aware executor)
- `McpProperties` (`staleThresholdMinutes` / `autoRefreshEnabled`) and the corresponding yml blocks
- `ReservedSnapshotNameException` and the `RESERVED_NAME_PREFIX` filters on `SnapshotService.listSnapshots` / `saveSnapshotWithLimit`
- The `__ai__` seed row (`test-data-set-1.1.5.sql`)

Auth + envelope is the only deliverable here.

## Test plan

- [x] `CustomerRepositoryTest.findByLicenseKey` — happy path + unknown key
- [x] `ApiKeyAuthInterceptorTest` (`@SpringBootTest` with seeded H2 data) — header missing / blank / invalid / valid
- [x] `SnapshotServiceTest` — REQUIRES_NEW survives outer rollback (proves the AOP fix)
- [x] `./gradlew :scavenger-api:test`
- [x] `./gradlew :scavenger-api:ktlintCheck`

Refs #170
