### PR TITLE
Bump Kotlin to 2.3.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     idea
     id("net.researchgate.release") version "3.1.0"
-    kotlin("jvm") version "2.3.0" apply false
+    kotlin("jvm") version "2.3.21" apply false
 }
 
 allprojects {

--- a/scavenger-api/build.gradle.kts
+++ b/scavenger-api/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-    val kotlinVersion = "2.3.0"
+    val kotlinVersion = "2.3.21"
     val springBootVersion = "3.5.9"
     val springDependencyManagementVersion = "1.1.7"
 

--- a/scavenger-collector/build.gradle.kts
+++ b/scavenger-collector/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-    val kotlinVersion = "2.3.0"
+    val kotlinVersion = "2.3.21"
     val springBootVersion = "3.5.9"
     val springDependencyManagementVersion = "1.1.7"
 

--- a/scavenger-demo-extension/build.gradle.kts
+++ b/scavenger-demo-extension/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.0"
-    kotlin("plugin.spring") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
 }
 
 repositories {

--- a/scavenger-demo/build.gradle.kts
+++ b/scavenger-demo/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "3.5.9"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "2.3.0"
-    kotlin("plugin.spring") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
 }
 
 repositories {

--- a/scavenger-entity/build.gradle.kts
+++ b/scavenger-entity/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    val kotlinVersion = "2.3.0"
+    val kotlinVersion = "2.3.21"
 
     java
     kotlin("jvm") version kotlinVersion

--- a/scavenger-model/build.gradle.kts
+++ b/scavenger-model/build.gradle.kts
@@ -3,7 +3,7 @@ import com.google.protobuf.gradle.id
 plugins {
     `java-library`
     idea
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.21"
     id("com.google.protobuf") version "0.9.5"
 }
 


### PR DESCRIPTION
## Summary

Patch version bump of the Kotlin Gradle plugin from 2.3.0 to 2.3.21 across the multi-module repo. SemVer-compatible patch release; no source changes.

## Files changed

- `build.gradle.kts` (root)
- `scavenger-api/build.gradle.kts`
- `scavenger-entity/build.gradle.kts`
- `scavenger-collector/build.gradle.kts`
- `scavenger-demo/build.gradle.kts`
- `scavenger-demo-extension/build.gradle.kts`
- `scavenger-model/build.gradle.kts`

The remaining modules (`scavenger-agent-java`, `scavenger-agent-python`, `scavenger-old-agent-java`, `scavenger-old-model`, `scavenger-schema`, `scavenger-frontend`) declare `kotlin("jvm")` without an explicit version and inherit from the root, so they pick up 2.3.21 automatically.

## Test plan

- [x] `./gradlew build` — full build, includes test + ktlintCheck + integrationTest across all JDK versions configured in the agent suite (84 tasks, all passing)
- [x] `./gradlew check` — green
- [x] No source changes; behavior unchanged (patch release)

## Out of scope

- Consolidating the explicit `kotlinVersion` declarations into a single root-level definition (separate refactor PR)
- Other dependency bumps